### PR TITLE
github: Update rakons to rkel

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -421,7 +421,6 @@ rado17,member
 Rafal-Nordic,member
 raffarost,member
 rajb9,member
-rakons,member
 ranj063,member
 raveenp,member
 Raymond0225,member
@@ -432,6 +431,7 @@ rerickson1,member
 rettichschnidi,member
 rghaddab,member
 RichardSWheatley,member
+rkel,member
 rljordan,member
 rlubos,member
 rmstoi,member


### PR DESCRIPTION
Add @rkel to the 'contributors' team removing @rakons account. Currently @rakons account is used mainly for maintenance.